### PR TITLE
Companion object extension methods

### DIFF
--- a/src/main/scala/collectmacros/package.scala
+++ b/src/main/scala/collectmacros/package.scala
@@ -48,15 +48,15 @@ final class Desugar(val c: blackbox.Context) {
 
 object `package` {
 
-  implicit class ListExt(val companion: List.type) {
+  implicit class ListExt(val companion: List.type) extends AnyVal {
     def construct[A](xs: A*): List[A] = macro xList.applyImpl[A]
   }
 
-  implicit class VectorExt(val companion: Vector.type) {
+  implicit class VectorExt(val companion: Vector.type) extends AnyVal {
     def construct[A](xs: A*): Vector[A] = macro xVector.applyImpl[A]
   }
 
-  implicit class ArrayExt(val companion: Array.type) {
+  implicit class ArrayExt(val companion: Array.type) extends AnyVal {
     def construct[A](xs: A*): Array[A] = macro xArray.applyImpl[A]
   }
 

--- a/src/main/scala/collectmacros/package.scala
+++ b/src/main/scala/collectmacros/package.scala
@@ -2,10 +2,6 @@ package collectmacros
 
 import scala.reflect.macros.blackbox
 
-object xList {
-  def apply[A](xs: A*): List[A] = macro xList.applyImpl[A]
-}
-
 final class xList(val c: blackbox.Context) {
   import c.universe._
 
@@ -14,10 +10,6 @@ final class xList(val c: blackbox.Context) {
 
   def applyImpl[A](xs: Tree*)(implicit A: WeakTypeTag[A]) =
     xs.foldRight(NilObject: Tree)((next, acc) => q"new $ConsType[$A]($next, $acc)")
-}
-
-object xVector {
-  def apply[A](xs: A*): Vector[A] = macro xVector.applyImpl[A]
 }
 
 final class xVector(val c: blackbox.Context) {
@@ -29,10 +21,6 @@ final class xVector(val c: blackbox.Context) {
     if (xs.isEmpty) q"$VectorObject.empty[$A]"
     else q"{ val b = $VectorObject.newBuilder[$A]; ..${xs map (x => q"b += $x")}; b.result() }"
   }
-}
-
-object xArray {
-  def apply[A](xs: A*): Array[A] = macro xArray.applyImpl[A]
 }
 
 final class xArray(val c: blackbox.Context) {
@@ -56,4 +44,20 @@ object Desugar {
 final class Desugar(val c: blackbox.Context) {
   import c.universe._
   def desugarImpl(a: Tree) = Literal(Constant(showRaw(a)))
+}
+
+object `package` {
+
+  implicit class ListExt(val companion: List.type) {
+    def construct[A](xs: A*): List[A] = macro xList.applyImpl[A]
+  }
+
+  implicit class VectorExt(val companion: Vector.type) {
+    def construct[A](xs: A*): Vector[A] = macro xVector.applyImpl[A]
+  }
+
+  implicit class ArrayExt(val companion: Array.type) {
+    def construct[A](xs: A*): Array[A] = macro xArray.applyImpl[A]
+  }
+
 }

--- a/src/test/scala/collectmacros/Usage.scala
+++ b/src/test/scala/collectmacros/Usage.scala
@@ -12,12 +12,12 @@ case object D extends C
 
 object Usage {
   def main(args: Array[String]): Unit = {
-    assertEquals(xList(1, 2, 3), List(1, 2, 3))
-    assertEquals(xList(1, 2, 3), 1 :: 2 :: 3 :: Nil)
-    assertEquals(xList(B2, C2, D), List(B2, C2, D))
-    assertEquals(xList(B2, C2, D), B2 :: C2 :: D :: Nil)
-    assertEquals(xVector(1, 2, 3), Vector(1, 2, 3))
-    assertEquals(xVector(B2, C2, D), Vector(B2, C2, D))
+    assertEquals(List.construct(1, 2, 3), List(1, 2, 3))
+    assertEquals(List.construct(1, 2, 3), 1 :: 2 :: 3 :: Nil)
+    assertEquals(List.construct(B2, C2, D), List(B2, C2, D))
+    assertEquals(List.construct(B2, C2, D), B2 :: C2 :: D :: Nil)
+    assertEquals(Vector.construct(1, 2, 3), Vector(1, 2, 3))
+    assertEquals(Vector.construct(B2, C2, D), Vector(B2, C2, D))
   }
 
   def assertEquals[T](l: T, r: T) = {


### PR DESCRIPTION
This uses the extension-method pattern to provide a `construct` method
on existing `List`, `Vector` and `Array` companion objects.

Check that this hasn't created some additional garbage along the way.